### PR TITLE
Added support for addon-hints for configuration of minFpm of categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,33 @@ To enable it go to landing_rate folder and open addon-config.xml. Find sharemp l
 ```<sharemp>0</sharemp>```
 
 Change sharemp value (1 for yes and 0 for no). Restart your simulator. Done.
+
+
+### Aircraft developer info
+
+#### Compatibility
+To make the plane compatible, it should initialize and calculate the following properties:
+
+- `/accelerations/pilot-gdamped`
+- `/instrumentation/vertical-speed-indicator/indicated-speed-fpm`
+- `/instrumentation/vertical-speed-indicator/indicated-speed-mps`
+
+
+#### Overriding landing category limits
+
+You can specify addon-hints in your aircraft.xml to override the landing category limits like this:
+```xml
+<sim>
+    <addon-hints>
+        <landing_rate>
+            <ranks>
+                <bad>
+                    <min-fpm>150</min-fpm>
+                </bad>
+            </ranks>
+        </landing_rate>
+    </addon-hints>
+</sim>
+```
+
+Valid `<ranks>` tags are: `bad`, `acceptable`, `good`, `very-good`, `excellent`. Use `fgfs --log-level=debug --log-class=nasal` to see what is actually loaded.

--- a/addon-metadata.xml
+++ b/addon-metadata.xml
@@ -8,7 +8,7 @@
     <addon>
         <identifier type="string">org.flightgear.addons.landing-rate</identifier>
         <name type="string">Landing Rate</name>
-        <version type="string">1.0.0</version>
+        <version type="string">1.1.0</version>
 
         <authors>
             <author>


### PR DESCRIPTION
- Init restructured, made more friendly (no exceptoin but nice warning on shutdown)
- Evaluation of /sim/addon-hints/landing_rate/ranks/ nodes

Resolves #6 