### PR TITLE
Dynamic config for Ranks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ To make the plane compatible, it should initialize and calculate the following p
 - `/instrumentation/vertical-speed-indicator/indicated-speed-mps`
 
 
+#### Presets based on ICAO wake turbolence category
+
+If your plane defines the `/aircraft/icao/wake-turbulence-category` property (either `L`, `M`, `H` or `J`), the plugin initializes a preset for that category as it guesses the size of the plane.
+
 #### Overriding landing category limits
 
 You can specify addon-hints in your aircraft.xml to override the landing category limits like this:

--- a/addon-config.nas
+++ b/addon-config.nas
@@ -1,0 +1,60 @@
+#
+# Addon Nasal file for additional configs.
+# We have it outsourced, in order to separate the main code from
+# internal config logic (the main code remains cleaner).
+#
+var LANDING_RANK_CFG = props.Node.new({
+
+    # Table for guessing landing rates from optionally set ICAO data in aircraft.xml
+    # in "/aircraft/icao/wake-turbulence-category" (J, H, M, L)
+    # see https://skybrary.aero/articles/icao-wake-turbulence-category
+    "icao-wake-turbulence-category": {
+        L: {
+            ranks: {
+                "bad":        {"min-fpm":300},
+                "acceptable": {"min-fpm":200},
+                "good":       {"min-fpm":100},
+                "very-good":  {"min-fpm":50}
+            }
+        },
+        # TODO: need better data for these!
+        M: {
+            ranks: {
+                "bad":        {"min-fpm":400},
+                "acceptable": {"min-fpm":300},
+                "good":       {"min-fpm":200},
+                "very-good":  {"min-fpm":100}
+            }
+        },
+        H: {
+            ranks: {
+                "bad":        {"min-fpm":600},
+                "acceptable": {"min-fpm":400},
+                "good":       {"min-fpm":200},
+                "very-good":  {"min-fpm":100}
+            }
+        },
+        J: {
+            ranks: {
+                "bad":        {"min-fpm":600},
+                "acceptable": {"min-fpm":400},
+                "good":       {"min-fpm":200},
+                "very-good":  {"min-fpm":100}
+            }
+        }
+    },
+
+    # Table for specific Aircraft types in "/sim/aircraft"
+    # (this is an addon-side alternative for addon-hints from the aircraft)
+    "aircraft-types": {
+        "ask21-jsb": {
+            ranks: {
+                "bad":        {"min-fpm":120},
+                "acceptable": {"min-fpm":80},
+                "good":       {"min-fpm":50},
+                "very-good":  {"min-fpm":35}
+            }
+        }
+    },
+
+});

--- a/addon-config.xml
+++ b/addon-config.xml
@@ -7,6 +7,25 @@
                 <addon-devel>
                     <sharemp>0</sharemp> <!-- share and send mp message when land? 1: yes 0: no -->
                 </addon-devel>
+                <ranks>
+                    <bad>
+                        <min-fpm>600</min-fpm>
+                    </bad>
+                    <acceptable>
+                        <min-fpm>400</min-fpm>
+                    </acceptable>
+                    <good>
+                        <min-fpm>200</min-fpm>
+                    </good>
+                    <very-good>
+                        <min-fpm>100</min-fpm>
+                    </very-good>
+
+                    <!-- excellent is default, never override -->
+                    <excellent>
+                        <min-fpm>0</min-fpm>
+                    </excellent>
+                </ranks>
             </org.flightgear.addons.landing-rate>
         </by-id>
     </addons>

--- a/addon-main.nas
+++ b/addon-main.nas
@@ -31,48 +31,7 @@ var LANDING_RANK = [
 
 
 # Additional configs
-var LANDING_RANK_CFG = props.Node.new({
-    # Table for guessing landing rates from optionally set ICAO data in aircraft.xml
-    # in "/aircraft/icao/wake-turbulence-category" (J, H, M, L)
-    # see https://skybrary.aero/articles/icao-wake-turbulence-category
-    "icao-wake-turbulence-category": {
-        L: {
-            ranks: {
-                "bad":        {"min-fpm":300},
-                "acceptable": {"min-fpm":200},
-                "good":       {"min-fpm":100},
-                "very-good":  {"min-fpm":50}
-            }
-        },
-        # TODO: need better data for these!
-        M: {
-            ranks: {
-                "bad":        {"min-fpm":400},
-                "acceptable": {"min-fpm":300},
-                "good":       {"min-fpm":200},
-                "very-good":  {"min-fpm":100}
-            }
-        },
-        H: {
-            ranks: {
-                "bad":        {"min-fpm":600},
-                "acceptable": {"min-fpm":400},
-                "good":       {"min-fpm":200},
-                "very-good":  {"min-fpm":100}
-            }
-        },
-        J: {
-            ranks: {
-                "bad":        {"min-fpm":600},
-                "acceptable": {"min-fpm":400},
-                "good":       {"min-fpm":200},
-                "very-good":  {"min-fpm":100}
-            }
-        }
-    }
-});
-
-
+io.include("addon-config.nas");
 
 
 var window = screen.window.new(10, 10, 3, 10); # create new window object, x = 10, y = 10, maxlines = 3, autoscroll = 10
@@ -216,10 +175,18 @@ var main = func (addon) {
 
                 # If defined, load ICAO wake turbulence guess values
                 var icao_wake_t_cat = getprop("/aircraft/icao/wake-turbulence-category");
-                if (icao_wake_t_cat != "") {
+                if (icao_wake_t_cat != nil and icao_wake_t_cat != "") {
                     var icao_wake_t_cat_cfg = LANDING_RANK_CFG.getNode("icao-wake-turbulence-category/"~icao_wake_t_cat);
                     if (icao_wake_t_cat_cfg != nil)
                         evaluateLandingRateAddonCfg(icao_wake_t_cat_cfg, addon);
+                }
+
+                # If defined, load aircraft type values
+                var aircraft = getprop("/sim/aircraft");
+                if (aircraft != nil and aircraft != "") {
+                    var aircraft_type_cfg = LANDING_RANK_CFG.getNode("aircraft-types/"~aircraft);
+                    if (aircraft_type_cfg != nil)
+                        evaluateLandingRateAddonCfg(aircraft_type_cfg, addon);
                 }
 
                 # load addon-hints from aircraft


### PR DESCRIPTION
Changed/Enhanced config loading:
* The addon now first applies the default config given in `addon-config.xml`.
* Then, it guesses the aircraft size ( ICAO wake turbulence category based on `/aircraft/icao/wake-turbulence-category`) and if so, applies a preset (hardcoded in the addon)
* Finally, the config can be changed at runtime by setting props below addon config base path (`/addons/by-id/org.flightgear.addons.landing-rate/ranks/`)